### PR TITLE
Technical fixes to roi_extract.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ neat.
 ### Changed
 - Changed takesnap inf view angle to fix shadow from @judyseinkim.
 - Changed scripts to record version number from @clane9.
+- Changed method for computing beta values in roi_extract. Previously, betas were
+  computed the naive way, by explicitly inverting `X' * X`. Although correct,
+  this is slow and numerically unstable. It's better to use the SVD, as
+  discussed [on wikipedia](https://en.wikipedia.org/wiki/Linear_least_squares_(mathematics)#Orthogonal_decomposition_methods).
+
+### Fixed
+- Redundant spike covariates are now removed before fitting the GLM. This
+  prevents the "Design matrix is rank-deficient" error from coming up in this
+  case.
 
 ## [1.0] - 2016-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ neat.
 - Changed method for computing beta values in roi_extract. Previously, betas were
   computed the naive way, by explicitly inverting `X' * X`. Although correct,
   this is slow and numerically unstable. It's better to use the SVD, as
-  discussed [on wikipedia](https://en.wikipedia.org/wiki/Linear_least_squares_(mathematics)#Orthogonal_decomposition_methods).
+  discussed [on wikipedia](https://en.wikipedia.org/wiki/Linear_least_squares_(mathematics)#Orthogonal_decomposition_methods)
+  (from @clane9).
 
 ### Fixed
 - Redundant spike covariates are now removed before fitting the GLM. This
   prevents the "Design matrix is rank-deficient" error from coming up in this
-  case.
+  case (from @clane9).
 
 ## [1.0] - 2016-08-09
 

--- a/bin/roi_extract
+++ b/bin/roi_extract
@@ -650,7 +650,7 @@ def read_run_cfds(run_cfds, run_len):
           keep_mask[i] = 0
         else:
           spike_inds.append(spike_ind)
-    run_cfd = run_cfd(:, keep_mask==1)
+    run_cfd = run_cfd[:, keep_mask==1]
   return run_cfd, spike_mask
 
 class Events(object):

--- a/bin/roi_extract
+++ b/bin/roi_extract
@@ -632,7 +632,10 @@ def read_run_cfds(run_cfds, run_len):
 
     # Determine type of confound
     # Normalize continuous covariates (in particular, center)
+    # Also, remove any redundant spike covariates
     spike_mask = np.ones(run_cfd.shape[1], dtype=int)
+    keep_mask = np.ones(run_cfd.shape[1], dtype=int)
+    spike_inds = [];
     for i in range(run_cfd.shape[1]):
       if np.sum(run_cfd[:, i] == np.round(run_cfd[:, i])) < run_len:
         run_cfd[:, i] = normalize(run_cfd[:, i])
@@ -640,6 +643,14 @@ def read_run_cfds(run_cfds, run_len):
       elif np.sum(run_cfd[:, i]) != 1.:
         raise NPDLError(('Only continuous covariates and spike regressors' +
                         'accepted as confounds.'))
+      else:
+        # Check if spike covariate is redundant.
+        spike_ind = np.argmax(run_cfd[:, i])
+        if spike_ind in spike_inds:
+          keep_mask[i] = 0
+        else:
+          spike_inds.append(spike_ind)
+    run_cfd = run_cfd(:, keep_mask==1)
   return run_cfd, spike_mask
 
 class Events(object):


### PR DESCRIPTION
- Betas are now computed in a more numerically stable way in the fit_glm function.
- Redundant spike regressors are handled better in roi_extract, to prevent the "Design matrix is rank-deficient" error from coming up.